### PR TITLE
Support non generic overload for GraphNode.To()

### DIFF
--- a/src/Dse.Test.Unit/Graph/GraphResultTests.cs
+++ b/src/Dse.Test.Unit/Graph/GraphResultTests.cs
@@ -9,6 +9,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Text;
 using Dse;
 using Dse.Geometry;
 using Dse.Graph;
@@ -106,6 +107,35 @@ namespace Dse.Test.Unit.Graph
             TestTo("{\"result\": \"92d4a960-1cf3-11e6-9417-bd9ef43c1c95\"}", (TimeUuid)Guid.Parse("92d4a960-1cf3-11e6-9417-bd9ef43c1c95"));
         }
 
+        [Test]
+        public void To_Should_Throw_For_Not_Supported_Types()
+        {
+            const string json = "{\"result\": \"123\"}";
+            var types = new [] { typeof(UIntPtr), typeof(IntPtr), typeof(StringBuilder) };
+            foreach (var t in types)
+            {
+                Assert.Throws<NotSupportedException>(() => new GraphNode(json).To(t));
+            }
+        }
+
+        [Test]
+        public void To_T_Should_Throw_For_Not_Supported_Types()
+        {
+            const string json = "{\"result\": \"123\"}";
+            TestToThrows<IntPtr, NotSupportedException>(json);
+            TestToThrows<UIntPtr, NotSupportedException>(json);
+            TestToThrows<StringBuilder, NotSupportedException>(json);
+        }
+
+        [Test]
+        public void Get_T_Should_Throw_For_Not_Supported_Types()
+        {
+            const string json = "{\"result\": {\"something\": \"123\" }}";
+            TestGetThrows<IntPtr, NotSupportedException>(json, "something");
+            TestGetThrows<UIntPtr, NotSupportedException>(json, "something");
+            TestGetThrows<StringBuilder, NotSupportedException>(json, "something");
+        }
+
         private static void TestGet<T>(string json, string property, T expectedValue)
         {
             var result = new GraphNode(json);
@@ -117,10 +147,20 @@ namespace Dse.Test.Unit.Graph
             Assert.AreEqual(expectedValue, result.Get<T>(property));
         }
 
+        private static void TestGetThrows<T, TException>(string json, string property) where TException : Exception
+        {
+            Assert.Throws<TException>(() => new GraphNode(json).Get<T>(property));
+        }
+
         private static void TestTo<T>(string json, T expectedValue)
         {
             var result = new GraphNode(json);
             Assert.AreEqual(expectedValue, result.To<T>());
+        }
+
+        private static void TestToThrows<T, TException>(string json) where TException : Exception
+        {
+            Assert.Throws<TException>(() => new GraphNode(json).To<T>());
         }
 
         [Test]

--- a/src/Dse/Graph/GraphNode.cs
+++ b/src/Dse/Graph/GraphNode.cs
@@ -175,15 +175,19 @@ namespace Dse.Graph
         /// </summary>
         private T GetTokenValue<T>(JToken token)
         {
-            var type = typeof (T);
+            return (T)GetTokenValue(token, typeof(T));
+        }
+
+        private object GetTokenValue(JToken token, Type type)
+        {
             if (token is JValue)
             {
-                if (typeof (T) == typeof (TimeUuid))
+                if (type == typeof (TimeUuid))
                 {
                     // TimeUuid is not Serializable but convertible from Uuid
-                    return (T)(object)(TimeUuid)token.ToObject<Guid>();
+                    return (TimeUuid)token.ToObject<Guid>();
                 }
-                return token.ToObject<T>(Serializer);
+                return token.ToObject(type, Serializer);
             }
             if (token is JObject)
             {
@@ -193,7 +197,7 @@ namespace Dse.Graph
                     throw new InvalidCastException(string.Format("Can not convert from an object tree to {0}: {1}", 
                         type.Name, token));
                 }
-                return (T) (object) new GraphNode(token);
+                return new GraphNode(token);
             }
             if (token is JArray)
             {
@@ -206,7 +210,7 @@ namespace Dse.Graph
                 {
                     elementType = type.GetTypeInfo().GetGenericArguments()[0];
                 }
-                return (T) (object) ToArray((JArray)token, elementType);
+                return ToArray((JArray)token, elementType);
             }
             throw new NotSupportedException(string.Format("Token of type {0} is not supported", token.GetType()));
         }
@@ -336,6 +340,11 @@ namespace Dse.Graph
         public T To<T>()
         {
             return GetTokenValue<T>(_parsedGraphItem);
+        }
+
+        public object To(Type type)
+        {
+            return GetTokenValue(_parsedGraphItem, type);
         }
 
         private Array ToArray(JArray jArray, Type elementType = null)


### PR DESCRIPTION
Includes a rebased version of #50 with additional tests and validation.

Fixes: CSHARP-584.